### PR TITLE
fix function parse_grid_datetime for pyart 1.12

### DIFF
--- a/tint/grid_utils.py
+++ b/tint/grid_utils.py
@@ -19,7 +19,8 @@ def parse_grid_datetime(grid_obj):
     dt_string = grid_obj.time['units'].split(' ')[-1]
     date = dt_string[:10]
     time = dt_string[11:19]
-    dt = datetime.datetime.strptime(date + ' ' + time, '%Y-%m-%d %H:%M:%S')
+    dt0 = datetime.datetime.strptime(date + ' ' + time, '%Y-%m-%d %H:%M:%S')
+    dt = datetime.timedelta(seconds=grid_obj.time['data'][0]) + dt0
     return dt
 
 


### PR DESCRIPTION
pyart grid object .time now returns number of seconds since a certain date/epoch (2001-01-01 00:00:00 UTC). This fix combines the epoch with the integer number of seconds for deriving the datetime object for the date and time of the grid scan