### PR TITLE
Filter out MDM files

### DIFF
--- a/tint/data_utils.py
+++ b/tint/data_utils.py
@@ -64,7 +64,7 @@ def get_nexrad_keys(site, start=None, end=None):
 
     keys = [key for date_key in date_keys
             for key in list(bucket.list(date_key))
-            if '.tar' not in str(key)]
+            if (('.tar' not in str(key)) and ('_MDM' not in str(key)))]
 
     if len(keys) == 0:
         print('Found 0 files.')


### PR DESCRIPTION
The NEXRAD bucket for KHGX on 20170713 contains files like `KHGX20170713_005757_V06_MDM` which causes this error:

```
Traceback (most recent call last):
  File "/Users/ebruning/code/tracer-jcss/grid_pol_nexrad.py", line 66, in <module>
    keys = get_nexrad_keys(args.site, start=args.start, end=args.end)
  File "/Users/ebruning/code/TINT/tint/data_utils.py", line 87, in get_nexrad_keys
    datetime.strptime(str(key).split('/')[-1], key_fmt_earlier))
  File "/Users/ebruning/miniconda3/envs/tobac-dev/lib/python3.9/_strptime.py", line 568, in _strptime_datetime
    tt, fraction, gmtoff_fraction = _strptime(data_string, format)
  File "/Users/ebruning/miniconda3/envs/tobac-dev/lib/python3.9/_strptime.py", line 349, in _strptime
    raise ValueError("time data %r does not match format %r" %
ValueError: time data 'KHGX20170713_005757_V06_MDM>' does not match format 'KHGX%Y%m%d_%H%M%S>'
```

This commit removes those files from the list of keys returned by `tint.data_utils.get_nexrad_keys`.